### PR TITLE
add Typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,34 @@
+import express = require('express');
+
+export type Ip              = string;
+export type CidrRange       = string;
+export type Route           = string;
+export type StartEndIpRange = Ip[];
+export type IpRange         = CidrRange | StartEndIpRange;
+export type IpList          = Array<Ip | IpRange>;
+
+export interface IpCallback {
+  (): IpList;
+}
+
+export interface IpFilterOptions {
+  detectIp?: (request: express.Request) => Ip;
+  excluding?: Route[];
+  log?: boolean;
+  logLevel?: 'all' | 'deny' | 'allow';
+  mode?: 'deny' | 'allow';
+  // `@types/proxy-addr` does not export the `trust` parameter type
+  trustProxy?: any;
+}
+
+export function IpFilter(
+  ips: IpList | IpCallback,
+  opts?: IpFilterOptions,
+): express.RequestHandler;
+
+export class IpDeniedError extends Error {
+  constructor(
+    message: string,
+    extra: any,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "author": "casz",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "/index.js",
     "/lib"


### PR DESCRIPTION
Adds Typescript types.

Type tests were originally written here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/65c27da832d7c7e5264f0982d879f651158dc872/types/express-ipfilter/express-ipfilter-tests.ts

Closing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38385 in favor of this this PR.