### PR TITLE
include types when publishing module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "types": "index.d.ts",
   "files": [
     "/index.js",
+    "/index.d.ts",
     "/lib"
   ],
   "scripts": {


### PR DESCRIPTION
This should allow the type definition file (#13) to be published with the package.